### PR TITLE
fix(ci): add pnpm setup and exclude CHANGELOG from formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
       - uses: voidzero-dev/setup-vp@624fe22ccfe9204a526ac8139186d34297453722 # v1.4.0
         with:
           node-version-file: package.json

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  fmt: {
+    ignorePatterns: ["**/CHANGELOG.md"],
+  },
   run: {
     cache: {
       tasks: true,


### PR DESCRIPTION
## Summary

- release ワークフローに `pnpm/action-setup` を追加し、`pnpm` コマンドが利用可能に
- `vite.config.ts` の `fmt.ignorePatterns` で `CHANGELOG.md` をフォーマット対象外に

## Test plan

- [ ] Release ワークフローで `pnpm release` が正常に実行されることを確認
- [ ] `vp check` で CHANGELOG.md のフォーマットエラーが出ないことを確認