### PR TITLE
ci: use k8o bot for changesets release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,27 @@ jobs:
           client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
           private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
 
+      - name: Resolve GitHub App user id
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          APP_SLUG: ${{ steps.generate-token.outputs.app-slug }}
+        run: |
+          user_id=$(gh api "users/${APP_SLUG}[bot]" --jq .id)
+          echo "id=${user_id}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Configure git user as GitHub App
+        env:
+          APP_SLUG: ${{ steps.generate-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.id }}
+        run: |
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
@@ -40,6 +57,7 @@ jobs:
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: pnpm release
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Configure git user as the k8o-bot GitHub App user before running `changesets/action`
- Pass `setupGitUser: false` so the action doesn't overwrite the configured user with the default `github-actions[bot]`
- Mirrors the release workflow used in [k35o/arte-odyssey](https://github.com/k35o/arte-odyssey/blob/main/.github/workflows/release.yml)

Now the "Version Packages" PR and release commits are authored by `k8o-bot[bot]` instead of the default `github-actions[bot]`.

## Test plan

- [ ] Workflow run succeeds on merge to main
- [ ] The Version Packages PR (when there is a pending changeset) is opened by k8o-bot