### PR TITLE
ci: make release-PR merges owner-triggered again

### DIFF
--- a/.changeset/manual-release-merge.md
+++ b/.changeset/manual-release-merge.md
@@ -1,0 +1,5 @@
+---
+"@better-css-modules/core": none
+---
+
+Stop auto-merging release PRs; merging the release PR is the owner's release trigger again.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,3 @@ jobs:
         with:
           build: pnpm build
           github-token: ${{ steps.generate-token.outputs.token }}
-          auto-merge: true


### PR DESCRIPTION
Removes `auto-merge: true` from the pnpm-release-action step in `release.yml`. Auto-merging the release PR was a convenience for the batch migration, not the desired steady state — merging the release PR is the owner's release trigger again.

Includes a bump-none intent (`.changeset/manual-release-merge.md`), so merging this PR releases nothing.